### PR TITLE
Prevent use of S.of(context) via automated review.

### DIFF
--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -16,9 +16,9 @@ flutter_lint.lint(inline_mode: true)
 files = git.added_files + git.modified_files
 files.each do |f|
     diff = git.diff_for_file(f)
-    // Check for uses of S.of(context) or similar
+    # Check for uses of S.of(context) or similar
     if diff.patch =~ /^\+.*S\.of\(.+\)/m
-        File.readlines(f).each do |line, index|
+        File.readlines('../../' + f).each_with_index do |line, index|
             if line =~ /S\.of\(.+\)/
                 warn("Use S.current instead of S.of(context)", file: f, line: index+1)
             end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -13,6 +13,19 @@ flutter_lint.only_modified_files = true
 flutter_lint.report_path = "flutter_analyze_report.txt"
 flutter_lint.lint(inline_mode: true)
 
+files = git.added_files + git.modified_files
+files.each do |f|
+    diff = git.diff_for_file(f)
+    // Check for uses of S.of(context) or similar
+    if diff.patch =~ /^\+.*S\.of\(.+\)/m
+        File.readlines(f).each do |line, index|
+            if line =~ /S\.of\(.+\)/
+                warn("Use S.current instead of S.of(context)", file: f, line: index+1)
+            end
+        end
+    end
+end
+
 # Analyze documentation
 textlint.config_file = '.github/linter/.textlintrc'
 textlint.max_severity = "warn"

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -17,8 +17,8 @@ files = git.added_files + git.modified_files
 files.each do |f|
     diff = git.diff_for_file(f)
     # Check for uses of S.of(context) or similar
-    if diff.patch =~ /^\+.*S\.of\(.+\)/m
-        File.readlines('../../' + f).each_with_index do |line, index|
+    if f =~ /.*\.dart/ and diff.patch =~ /^\+.*S\.of\(.+\)/m
+        File.readlines(f).each_with_index do |line, index|
             if line =~ /S\.of\(.+\)/
                 warn("Use S.current instead of S.of(context)", file: f, line: index+1)
             end

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,6 @@ import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
 import 'package:acs_upb_mobile/pages/settings/view/settings_page.dart';
 import 'package:acs_upb_mobile/pages/timetable/service/uni_event_provider.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
-import 'package:acs_upb_mobile/resources/remote_config.dart';
 import 'package:acs_upb_mobile/resources/utils.dart';
 import 'package:acs_upb_mobile/widgets/loading_screen.dart';
 import 'package:dynamic_theme/dynamic_theme.dart';
@@ -38,6 +37,7 @@ import 'package:preferences/preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:rrule/rrule.dart';
 import 'package:time_machine/time_machine.dart';
+import 'package:acs_upb_mobile/resources/remote_config.dart';
 
 // FIXME: acs.pub.ro has some bad certificate configuration right now, and the
 // cs.pub.ro certificate is expired.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
 import 'package:acs_upb_mobile/pages/settings/view/settings_page.dart';
 import 'package:acs_upb_mobile/pages/timetable/service/uni_event_provider.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
+import 'package:acs_upb_mobile/resources/remote_config.dart';
 import 'package:acs_upb_mobile/resources/utils.dart';
 import 'package:acs_upb_mobile/widgets/loading_screen.dart';
 import 'package:dynamic_theme/dynamic_theme.dart';
@@ -37,7 +38,6 @@ import 'package:preferences/preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:rrule/rrule.dart';
 import 'package:time_machine/time_machine.dart';
-import 'package:acs_upb_mobile/resources/remote_config.dart';
 
 // FIXME: acs.pub.ro has some bad certificate configuration right now, and the
 // cs.pub.ro certificate is expired.
@@ -140,6 +140,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    print(S.of(context).actionAddEvent);
     return DynamicTheme(
       defaultBrightness: SchedulerBinding.instance.window.platformBrightness,
       data: (brightness) => ThemeData(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,7 +140,6 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    print(S.of(context).actionAddEvent);
     return DynamicTheme(
       defaultBrightness: SchedulerBinding.instance.window.platformBrightness,
       data: (brightness) => ThemeData(


### PR DESCRIPTION
The context is no longer necessary to fetch localized strings, so the recommendation is to use `S.current` instead of `S.of(context)`.