### PR TITLE
Check that there's a space between // or /// and the actual comment

### DIFF
--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -26,7 +26,7 @@ files.each do |f|
         end
     end
 
-    # Check for lack of spaces after comments or dartdoc comments
+    # Check comment formatting
     if f =~ /.*\.dart/ and diff.patch =~ /((\/\/)[^ \n\/])|((\/\/\/)[^ \n])|(\/\*)/m
         File.readlines(f).each_with_index do |line, index|
             if line =~ /\/\*/

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -27,10 +27,15 @@ files.each do |f|
     end
 
     # Check for lack of spaces after comments or dartdoc comments
-    if f =~ /.*\.dart/ and diff.patch =~ /((\/\/)[^ \n\/])|((\/\/\/)[^ \n])/m
+    if f =~ /.*\.dart/ and diff.patch =~ /([^ \n\/](\/\/))|((\/\/)[^ \n\/])|((\/\/\/)[^ \n])/m
         File.readlines(f).each_with_index do |line, index|
+            if line =~ /[^ \n\/](\/\/)/
+                warn("Add a space between \"//\" and the code", file: f, line: index+1)
             if line =~ /(\/\/\/)[^ \n]/
-                warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
+                if line =~ /\/{4}/
+                    warn("That's probably too many slashes", file: f, line: index+1)
+                else
+                    warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
             elsif line =~ /(\/\/)[^ \n\/]/
                 warn("Add a space between \"//\" and the actual comment", file: f, line: index+1)
             end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -16,11 +16,23 @@ flutter_lint.lint(inline_mode: true)
 files = git.added_files + git.modified_files
 files.each do |f|
     diff = git.diff_for_file(f)
+
     # Check for uses of S.of(context) or similar
     if f =~ /.*\.dart/ and diff.patch =~ /^\+.*S\.of\(.+\)/m
         File.readlines(f).each_with_index do |line, index|
             if line =~ /S\.of\(.+\)/
                 warn("Use S.current instead of S.of(context)", file: f, line: index+1)
+            end
+        end
+    end
+
+    # Check for lack of spaces after comments or dartdoc comments
+    if f =~ /.*\.dart/ and diff.patch =~ /((\/\/)[^ \n\/])|((\/\/\/)[^ \n])/m
+        File.readlines(f).each_with_index do |line, index|
+            if line =~ /(\/\/\/)[^ \n]/
+                warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
+            elif line =~ /(\/\/)[^ \n]/
+                warn("Add a space between \"//\" and the actual comment", file: f, line: index+1)
             end
         end
     end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -36,6 +36,7 @@ files.each do |f|
                     warn("That's probably too many slashes", file: f, line: index+1)
                 else
                     warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
+                end
             elsif line =~ /(\/\/)[^ \n\/]/
                 warn("Add a space between \"//\" and the actual comment", file: f, line: index+1)
             end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -31,7 +31,7 @@ files.each do |f|
         File.readlines(f).each_with_index do |line, index|
             if line =~ /(\/\/\/)[^ \n]/
                 warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
-            elsif line =~ /(\/\/)[^ \n]/
+            elsif line =~ /(\/\/)[^ \n\/]/
                 warn("Add a space between \"//\" and the actual comment", file: f, line: index+1)
             end
         end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -27,12 +27,10 @@ files.each do |f|
     end
 
     # Check for lack of spaces after comments or dartdoc comments
-    if f =~ /.*\.dart/ and diff.patch =~ /([^ \n\/](\/\/))|((\/\/)[^ \n\/])|((\/\/\/)[^ \n])|(\/\*)/m
+    if f =~ /.*\.dart/ and diff.patch =~ /((\/\/)[^ \n\/])|((\/\/\/)[^ \n])|(\/\*)/m
         File.readlines(f).each_with_index do |line, index|
             if line =~ /\/\*/
                 warn("Don't use block comments", file: f, line: index+1)
-            elsif line =~ /[^ \n\/](\/\/)/
-                warn("Add a space between \"//\" and the code", file: f, line: index+1)
             elsif line =~ /(\/\/\/)[^ \n]/
                 if line =~ /\/{4}/
                     warn("That's probably too many slashes", file: f, line: index+1)

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -31,7 +31,7 @@ files.each do |f|
         File.readlines(f).each_with_index do |line, index|
             if line =~ /(\/\/\/)[^ \n]/
                 warn("Add a space between \"///\" and the actual comment", file: f, line: index+1)
-            elif line =~ /(\/\/)[^ \n]/
+            elsif line =~ /(\/\/)[^ \n]/
                 warn("Add a space between \"//\" and the actual comment", file: f, line: index+1)
             end
         end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -27,11 +27,13 @@ files.each do |f|
     end
 
     # Check for lack of spaces after comments or dartdoc comments
-    if f =~ /.*\.dart/ and diff.patch =~ /([^ \n\/](\/\/))|((\/\/)[^ \n\/])|((\/\/\/)[^ \n])/m
+    if f =~ /.*\.dart/ and diff.patch =~ /([^ \n\/](\/\/))|((\/\/)[^ \n\/])|((\/\/\/)[^ \n])|(\/\*)/m
         File.readlines(f).each_with_index do |line, index|
-            if line =~ /[^ \n\/](\/\/)/
+            if line =~ /\/\*/
+                warn("Don't use block comments", file: f, line: index+1)
+            elsif line =~ /[^ \n\/](\/\/)/
                 warn("Add a space between \"//\" and the code", file: f, line: index+1)
-            if line =~ /(\/\/\/)[^ \n]/
+            elsif line =~ /(\/\/\/)[^ \n]/
                 if line =~ /\/{4}/
                     warn("That's probably too many slashes", file: f, line: index+1)
                 else

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -262,10 +262,6 @@ Good:
 /// Good doc comment
 Some edge cases:
 
-// An empty comment with no spaces after is okay:
-//
-//
-
 // What about this:
 ///////////heey
 // //Is this alright?
@@ -276,3 +272,7 @@ Some edge cases:
 some comment // after code
 some other //after code comment
 ////what
+
+// An empty comment with no spaces after is okay:
+//
+//

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -271,6 +271,18 @@ int i; // after code
 int j; //after code comment
 ////what
 
+int k; //hello
+int l; // hello
+int m;
+
+/// hello
+int n;
+
+/// why would you dartdoc after code
+int o; //// too much slash
+
+///hello
+
 // An empty comment with no spaces after is okay:
 //
 //

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -256,11 +256,9 @@ class AppLoadingScreen extends StatelessWidget {
 
 //Bad comment
 ///Bad doc-comment
-Good:
 
 // Good comment
 /// Good doc comment
-Some edge cases:
 
 // What about this:
 ///////////heey
@@ -269,8 +267,8 @@ Some edge cases:
 // An empty comment at the end of the file is probably also okay:
 ///
 
-some comment // after code
-some other //after code comment
+int i; // after code
+int j; //after code comment
 ////what
 
 // An empty comment with no spaces after is okay:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -253,38 +253,3 @@ class AppLoadingScreen extends StatelessWidget {
     );
   }
 }
-
-//Bad comment
-///Bad doc-comment
-
-// Good comment
-/// Good doc comment
-
-// What about this:
-///////////heey
-// //Is this alright?
-
-// An empty comment at the end of the file is probably also okay:
-///
-
-int i; // after code
-int j; //after code comment
-////what
-
-int k; //hello
-int l; // hello
-int m;
-
-/// hello
-int n;
-
-/// why would you dartdoc after code
-int o; //// too much slash
-
-///hello
-
-/*don't like block comments*/
-
-// An empty comment with no spaces after is okay:
-//
-//

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -283,6 +283,8 @@ int o; //// too much slash
 
 ///hello
 
+/*don't like block comments*/
+
 // An empty comment with no spaces after is okay:
 //
 //

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -253,3 +253,26 @@ class AppLoadingScreen extends StatelessWidget {
     );
   }
 }
+
+//Bad comment
+///Bad doc-comment
+Good:
+
+// Good comment
+/// Good doc comment
+Some edge cases:
+
+// An empty comment with no spaces after is okay:
+//
+//
+
+// What about this:
+///////////heey
+// //Is this alright?
+
+// An empty comment at the end of the file is probably also okay:
+///
+
+some comment // after code
+some other //after code comment
+////what


### PR DESCRIPTION
Added a workflow rule that checks that there is a space after // or ///. The before-space is checked by the formatter already.

Additionally, also check that block comments aren't used ([style guide rule](https://dart.dev/guides/language/effective-dart/documentation#dont-use-block-comments-for-documentation)) and show a warning for sequences longer than 3 slashes.