### PR TITLE
Toast overlapped bug

### DIFF
--- a/lib/authentication/view/edit_profile_page.dart
+++ b/lib/authentication/view/edit_profile_page.dart
@@ -292,12 +292,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
                 if (uploadedImage != null) {
                   imageAsPNG = await Utils.convertToPNG(uploadedImage);
                   result = await authProvider.uploadProfilePicture(imageAsPNG);
-                  if (result) {
-                    AppToast.show(S.current.messagePictureUpdatedSuccess);
-                  }
                 }
                 if (result) {
                   if (await authProvider.updateProfile(info)) {
+
                     AppToast.show(S.current.messageEditProfileSuccess);
                     Navigator.pop(context);
                   }

--- a/lib/authentication/view/edit_profile_page.dart
+++ b/lib/authentication/view/edit_profile_page.dart
@@ -295,7 +295,6 @@ class _EditProfilePageState extends State<EditProfilePage> {
                 }
                 if (result) {
                   if (await authProvider.updateProfile(info)) {
-
                     AppToast.show(S.current.messageEditProfileSuccess);
                     Navigator.pop(context);
                   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.13+22
+version: 1.2.13+23
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Deleted the "edit profile successfully" toast because it was overlapping the "Profile updated successfully" toast.