### PR TITLE
Deploy security rules from repo

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,6 @@
 {
   "projects": {
-    "default": "acs-upb-mobile",
+    "prod": "acs-upb-mobile",
     "dev": "acs-upb-mobile-dev"
   }
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,19 @@ on:
 name: Deployment
 
 jobs:
+  firebase:
+    name: Firebase deployment
+    runs-on: ubuntu-latest
+    if: github.repository == 'student-hub/acs-upb-mobile'
+
+    steps:
+      - name: Deploy functions, rules and indexes to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only functions,storage,firestore --project prod
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
   web:
     name: Deploy website
     runs-on: ubuntu-latest
@@ -43,7 +56,7 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --only hosting --project default
+          args: deploy --only hosting --project prod
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -720,7 +720,7 @@ It contains app resources such as icons and profile pictures, organised similarl
 
 #### Security rules
 
-Storage security rules are similar to [Firestore security rules](#security-rules). One of the reasons for keeping the storage structure as close to possible to the Firestore structure is the ability to have similar security rules (for example, if, in Firestore, a user can only access their own document, the same rule can be applied for a user's folder inside Storage).
+Storage security rules are similar to [Firestore security rules](#security-rules). One of the reasons for keeping the storage structure as close as possible to the Firestore structure is the ability to have similar security rules (for example, if, in Firestore, a user can only access their own document, the same rule can be applied for a user's folder inside Storage).
 
 More information on Storage security rules can be found [here](https://firebase.google.com/docs/storage/security).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,12 @@ It is recommended that you go through [our workshop](https://github.com/acs-upb-
   + [Authentication](#authentication)
   + [Firestore](#firestore)
     - [Data model](#data-model)
+    - [Security rules](#security-rules)
+    - [Indexes](#indexes)
     - [Project database](#project-database)
   + [Storage](#storage)
     - [Structure](#structure)
-    - [Security](#security)
+    - [Security rules](#security-rules-1)
   + [Functions](#functions)
 * [Internationalization](#internationalization)
   + [On-device](#on-device)
@@ -94,8 +96,8 @@ Similarly, please create one PR per development item, instead of bundling multip
     * For simplicity, you could call the default "main.dart" configuration in Android Studio "Debug", duplicate it and call the second one "Release", with `--release` as an argument. For example:
     <img src=screenshots/other/release_configuration.png>
 
-| :exclamation: | On Android, ACS UPB Mobile uses **a separate (development) environment in debug mode**. That means a completely different Firebase project - separate data, including user info.|
-|---------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :exclamation: | On Android, ACS UPB Mobile uses **a separate (development) environment in debug mode**. That means a completely different Firebase project - separate data, including user info. You should ALWAYS use this environment for testing the app when modifying any kind of data, so as not to risk breaking something in the production database. |
+|---------------|:---------------|
 
 ## Style guide
 
@@ -119,17 +121,19 @@ The following actions are currently set up:
   - If at least one test fails, this workflow will fail.
   - The *coverage* is the percentage of lines of code that are executed at least once in tests. This project aims to keep coverage above 70% at all times.
 * [Deployment](https://github.com/acs-upb-mobile/acs-upb-mobile/actions?query=workflow%3ADeployment):
-  Deploys the app to [Google Play](https://play.google.com/store/apps/details?id=ro.pub.acs.acs_upb_mobile), as well as the website ([acs-upb-mobile.web.app](https://acs-upb-mobile.web.app/)), and creates a corresponding [GitHub Release](https://github.com/acs-upb-mobile/acs-upb-mobile/releases) including the APK. This action is triggered when a new version tag (e.g. `v1.2.10`) is pushed.
+  Deploys the app to [Google Play](https://play.google.com/store/apps/details?id=ro.pub.acs.acs_upb_mobile), as well as the website ([acs-upb-mobile.web.app](https://acs-upb-mobile.web.app/)), and creates a corresponding [GitHub Release](https://github.com/acs-upb-mobile/acs-upb-mobile/releases) including the APK. It also deploys Firebase functions as well as Firestore security rules and indexes (see [Working with Firebase](#working-with-firebase) for more info). This action is triggered when a new version tag (e.g. `v1.2.10`) is pushed.
   -  :exclamation: **Do not push version tags** unless you know what you are doing. If you do push a tag, you should annotate it (e.g. use a command like `git tag -a v1.2.10`) with the content of the en-US changelog file. The first line of the annotation should be the version (e.g. v1.2.10), followed by an empty line, followed by the content of the English changelog.
   - For the Google Play release, we are using [fastlane](https://fastlane.tools/). It requires creating changelog files in each supported language under [android/fastlane/metadata/android](android/fastlane/metadata/android), with the name `$(pubspec_build_number + 10000).txt`. For example, if the version in [pubspec.yaml](pubspec.yaml) is `1.2.10+12`, the files should be named `100012.txt`. The content of the changelog file is what the users will se under the "What's new" section in Google Play, and should use a friendly language and generally be organised by sections like `Added`, `Fixed`, `Improved` etc. Look at the existing changelogs for examples.
 
 ## Working with Firebase
-ACS UPB Mobile uses [Firebase](https://firebase.google.com/) - an app development platform built on Google infrastructure and using [Google Cloud Platform](https://cloud.google.com/) - to manage remote storage and authentication, as well as other cloud resources.
+ACS UPB Mobile uses [Firebase](https://firebase.google.com/) - an app development platform built on Google infrastructure and using [Google Cloud Platform](https://cloud.google.com/) - to manage remote storage and authentication, as well as other cloud resources. We have two separate projects for the app - one for production (acs-upb-mobile) and one for development (acs-upb-mobile-dev). The former is the "real" app with actual user data, and we use the latter when developing and adding new features to avoid causing disturbances in the production environment that users could notice. You can ask a maintainer to gain access to the development project, and in most cases you shouldn't need access to the production project.
 
 ### Setup
 This application uses [flutterfire](https://github.com/FirebaseExtended/flutterfire) plugins in order to access Firebase services. They are already enabled in the [pubspec](pubspec.yaml) file and ready to import and use in the code.
 
 :exclamation: FlutterFire only has [Cloud Storage](#storage) support for Android and iOS. The web version needs a special implementation. See [resources/storage](lib/resources/storage) for an example.
+
+Firebase projects can be managed through the [Firebase console](https://console.firebase.google.com/) and the [Firebase CLI](https://firebase.google.com/docs/cli). To set up the CLI tools, follow [the official instructions](https://firebase.google.com/docs/cli#install_the_firebase_cli). You should then authenticate using `firebase login`. You **DO NOT** need to run `firebase init`, as the project is already initialized in the repo.
 
 ### Authentication
 
@@ -146,7 +150,7 @@ Firebase Authentication stores [user information](https://firebase.google.com/do
 
 This service automatically *handles the authentication tokens* and *enforces security rules*, which is particularly useful for an open-source application which users can fiddle with, such as ours. For example, multiple failed authentication attempts lead to a temporary timeout, and a user cannot delete their account unless they have logged in very recently (or refreshed their authentication token).
 
-[Firestore security rules](#firestore-security) can be enforced based on the user’s UID. This method means that, even though users can access the database connection string through the public repository, they can only do a limited set of actions on the database, depending on whether they are authenticated and their permissions.
+[Firestore security rules](#security-rules) can be enforced based on the user’s UID. This method means that, even though users can access the database connection string through the public repository, they can only do a limited set of actions on the database, depending on whether they are authenticated and their permissions.
 
 ### Firestore
 [Cloud Firestore](https://firebase.google.com/docs/firestore) is a noSQL database that organises its data in *collections* and *documents*.
@@ -159,11 +163,36 @@ In addition to fields, documents can contain collections… which contain other 
 
 More information about the Firestore data model can be found [here](https://firebase.google.com/docs/firestore/data-model).
 
-<h4 id="firestore-security">Security</h4>
+#### Security rules
 
 Firestore allows for defining specific security rules for each collection. Rules can be applied for each different type of transaction - `reads` (where single-document reads - `get` - and queries - `list` - can have different rules) and `writes` (where `create`, `delete` and `update` can be treated separately).
 
 More information on Firestore security rules can be found [here](https://firebase.google.com/docs/firestore/security/rules-structure).
+
+You can update security rules directly from the Firebase console (select Firestore Database from the side menu, then click the "Rules" tab). However, that can lead to conflicts when we deploy the rules from [firestore.rules](firestore.rules). Always remember to update the repo file as well, otherwise you risk your changes being overwritten. In order to fetch the current rules and add them to the file, you can call:
+
+```cli
+firebase firestore:rules > firestore.rules
+```
+
+The preferred method to update security rules is through the [Firebase CLI](https://firebase.google.com/docs/cli) (see section [Setup](#setup) above). Simply edit the [firestore.rules](firestore.rules) file, then deploy the rules using the following commands:
+
+```cli
+firebase use dev # Make sure the dev environment is selected
+firebase deploy --only firestore:rules
+```
+
+You do not need to worry about deploying to the production environment, as that is handled by the automated scripts that run when you merge a PR (see [GitHub Actions](#github-actions)).
+
+#### Indexes
+
+Indexes are useful to improve query performance, and Firestore requires an index for every query. Basic indexes are already generated, and when you run a query that requires a new index, you will get an error and a link that will walk you through creating the necessary indexes.
+
+:exclamation: When you create a new index from the Firebase console, you must update the [firestore.indexes.json](firestore.indexes.json) file by calling:
+
+```cli
+firebase firestore:indexes > firestore.indexes.json
+```
 
 #### Project database
 The project database contains the following collections:
@@ -689,11 +718,22 @@ It contains app resources such as icons and profile pictures, organised similarl
 * **Website icons** are stored in the `websites/` directory. The icon of a website in Firestore that has the ID "abcd" will be in storage under `websites/abcd/icon.png`.
 * **Profile pictures** are stored in the `users/` directory. The picture of a user with the UID "abcd" would be in storage under `users/abcd/picture.png`.
 
-#### Security
+#### Security rules
 
-Storage security rules are similar to [Firestore security rules](#firestore-security). One of the reasons for keeping the storage structure as close to possible to the Firestore structure is the ability to have similar security rules (for example, if, in Firestore, a user can only access their own document, the same rule can be applied for a user's folder inside Storage).
+Storage security rules are similar to [Firestore security rules](#security-rules). One of the reasons for keeping the storage structure as close to possible to the Firestore structure is the ability to have similar security rules (for example, if, in Firestore, a user can only access their own document, the same rule can be applied for a user's folder inside Storage).
 
 More information on Storage security rules can be found [here](https://firebase.google.com/docs/storage/security).
+
+You can update security rules directly from the Firebase console (select Storage from the side menu, then click the "Rules" tab). However, that can lead to conflicts when we deploy the rules from [storage.rules](storage.rules). Always remember to update the repo file as well, otherwise you risk your changes being overwritten. As of Aug 2021, there is no CLI command to fetch the current rules, so you have to manually copy them from the console to the file.
+
+The preferred method to update security rules is through the [Firebase CLI](https://firebase.google.com/docs/cli) (see section [Setup](#setup) above). Simply edit the [storage.rules](storage.rules) file, then deploy the rules using the following commands:
+
+```cli
+firebase use dev # Make sure the dev environment is selected
+firebase deploy --only storage
+```
+
+You do not need to worry about deploying to the production environment, as that is handled by the automated scripts that run when you merge a PR (see [GitHub Actions](#github-actions)).
 
 ### Functions
 [Cloud Functions for Firebase](https://firebase.google.com/docs/functions) is a serverless solution for running bits of code in response to events or at scheduled time intervals. They are, for all intents and purposes, JavaScript/TypeScript functions that run directly "in the cloud", without needing to be tied to an app or device.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,13 +171,13 @@ More information on Firestore security rules can be found [here](https://firebas
 
 You can update security rules directly from the Firebase console (select Firestore Database from the side menu, then click the "Rules" tab). However, that can lead to conflicts when we deploy the rules from [firestore.rules](firestore.rules). Always remember to update the repo file as well, otherwise you risk your changes being overwritten. In order to fetch the current rules and add them to the file, you can call:
 
-```cli
+```bash
 firebase firestore:rules > firestore.rules
 ```
 
 The preferred method to update security rules is through the [Firebase CLI](https://firebase.google.com/docs/cli) (see section [Setup](#setup) above). Simply edit the [firestore.rules](firestore.rules) file, then deploy the rules using the following commands:
 
-```cli
+```bash
 firebase use dev # Make sure the dev environment is selected
 firebase deploy --only firestore:rules
 ```
@@ -190,7 +190,7 @@ Indexes are useful to improve query performance, and Firestore requires an index
 
 :exclamation: When you create a new index from the Firebase console, you must update the [firestore.indexes.json](firestore.indexes.json) file by calling:
 
-```cli
+```bash
 firebase firestore:indexes > firestore.indexes.json
 ```
 
@@ -728,7 +728,7 @@ You can update security rules directly from the Firebase console (select Storage
 
 The preferred method to update security rules is through the [Firebase CLI](https://firebase.google.com/docs/cli) (see section [Setup](#setup) above). Simply edit the [storage.rules](storage.rules) file, then deploy the rules using the following commands:
 
-```cli
+```bash
 firebase use dev # Make sure the dev environment is selected
 firebase deploy --only storage
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,11 +169,7 @@ Firestore allows for defining specific security rules for each collection. Rules
 
 More information on Firestore security rules can be found [here](https://firebase.google.com/docs/firestore/security/rules-structure).
 
-You can update security rules directly from the Firebase console (select Firestore Database from the side menu, then click the "Rules" tab). However, that can lead to conflicts when we deploy the rules from [firestore.rules](firestore.rules). Always remember to update the repo file as well, otherwise you risk your changes being overwritten. In order to fetch the current rules and add them to the file, you can call:
-
-```bash
-firebase firestore:rules > firestore.rules
-```
+You can update security rules directly from the Firebase console (select Firestore Database from the side menu, then click the "Rules" tab). However, that can lead to conflicts when we deploy the rules from [firestore.rules](firestore.rules). Always remember to update the repo file as well, otherwise you risk your changes being overwritten. As of Aug 2021, there is no CLI command to fetch the current rules, so you have to manually copy them from the console to the file.
 
 The preferred method to update security rules is through the [Firebase CLI](https://firebase.google.com/docs/cli) (see section [Setup](#setup) above). Simply edit the [firestore.rules](firestore.rules) file, then deploy the rules using the following commands:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ torvalds/android_speedups
 When developing a new feature or working on a bug, your pull request will end up containing fix-up commits (commits that change the same line of code repeatedly) or too fine-grained commits. An issue that can arise from this is that the main branch history will become polluted with unnecessary commits. To avoid it, we implement and enforce a squash policy.
 All commits that are merged into the main development branch have to be squashed ahead of the merge.
 You can do so by pressing "squash and merge" in GitHub (_recommended_), or, alternatively, following the generic local squash routine outlined bellow:
-```
+```bash
 git checkout your_branch_name
 git rebase -i HEAD~n
 # n is normally the number of commits in the pull request.

--- a/firebase.json
+++ b/firebase.json
@@ -27,5 +27,8 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -23,5 +23,9 @@
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ],
     "source": "functions"
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "class",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "start",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,125 @@
+// NOTE: Editing rules from the console can lead to conflicts. Always remember to update the GitHub
+// file as well, otherwise you risk your changes being overwritten.
+// https://firebase.google.com/docs/cli#deployment_conflicts
+
+rules_version = '2';
+service cloud.firestore {
+    // Check if user is authenticated
+    function isAuthenticated() {
+        return request.auth != null;
+    }
+
+    function last(some_list) {
+        return some_list[some_list.size() - 1];
+    }
+
+    // Check if user signed the new data (with their uid)
+    function didSign() {
+        return request.resource.data.addedBy == request.auth.uid || last(request.resource.data.editedBy) == request.auth.uid;
+    }
+
+    match /databases/{database}/documents {
+        // Get the authenticated user's permission level
+        function permissionLevel() {
+            return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.permissionLevel;
+        }
+
+        match /users/{user}/{document=**} {
+            function isOwner() {
+                return isAuthenticated() && request.auth.uid == user;
+            }
+
+            // Only allow users to see or delete their own data
+            allow read, delete: if isOwner();
+
+            // Allow anyone to create a new user with no permissions
+            allow create: if request.resource.data.permissionLevel == 0 || request.resource.data.permissionLevel == null || !('permissionLevel' in request.resource.data);
+
+            // Allow users to modify their own data, except for the permissionLevel
+            allow update: if isOwner() && (!('permissionLevel' in request.resource.data) || request.resource.data.permissionLevel == resource.data.permissionLevel);
+        }
+
+        match /websites/{website} {
+            function isOwner() {
+                return isAuthenticated() && request.auth.uid == resource.data.addedBy;
+            }
+
+            // Anyone can read
+            allow read: if true;
+
+            // Only authenticated users with permissionLevel >= 2 can write
+            // Data must be signed
+            allow create: if isAuthenticated() && didSign() && permissionLevel() >= 2;
+
+            // The 'addedBy' field cannot be modified
+            allow update: if (!('addedBy' in request.resource.data) || request.resource.data.addedBy == resource.data.addedBy) && isAuthenticated() && didSign() && permissionLevel() >= 2;
+
+            // Users can only delete a website they created unless their permissionLevel is 3 or higher
+            allow delete: if isOwner() || permissionLevel() >= 3;
+        }
+
+        match /filters/{filter} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /classes/{class}/{document=**} {
+            // Anyone can read
+            allow read: if true;
+
+            // Only authenticated users with permissionLevel >= 3 can edit
+            allow update, create: if isAuthenticated() && permissionLevel() >= 3;
+        }
+
+        match /people/{person} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /import_moodle/{class} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /import_studenti/{class} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /faq/{question} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /news/{announcement} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /events/{event} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            // Only authenticated users with permissionLevel >= 3 can edit
+            allow write: if isAuthenticated() && permissionLevel() >= 3;
+        }
+
+        match /calendars/{calendar} {
+            // Anyone can read, no one can write
+            allow read: if true;
+            allow write: if false;
+        }
+
+        match /forms/{form=**} {
+            allow read: if true;
+            allow create: if isAuthenticated();
+            allow update: if false;
+            allow delete: if false;
+        }
+    }
+}

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
-      "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
+      "integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw=="
     },
     "@firebase/auth-interop-types": {
       "version": "0.1.6",
@@ -40,48 +40,48 @@
       "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
     },
     "@firebase/component": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.1.tgz",
-      "integrity": "sha512-l1yYAH7OSdmaLXmVBR1vjop2WNELDty3G4NxLFLysWxkcTPhqG+PjKzHEEkAgJ2slF5H3O9BFOGP9OUtrHhvMA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.5.tgz",
+      "integrity": "sha512-L41SdS/4a164jx2iGfakJgaBUPPBI3DI+RrUlmh3oHSUljTeCwfj/Nhcv3S7e2lyXsGFJtAyepfPUx4IQ05crw==",
       "requires": {
-        "@firebase/util": "1.1.0",
+        "@firebase/util": "1.2.0",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@firebase/database": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.3.tgz",
-      "integrity": "sha512-PaQ2EEvx0LsWIqN7qsoqN4RiAJYs6FL5BFDFEPTjJZW410ECnMcNfXCASYuQSU903sY4MA0ki9H1nH0J7gb7bQ==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.9.tgz",
+      "integrity": "sha512-Jxi9SiE4cNOftO9YKlG71ccyWFw4kSM9AG/xYu6vWXUGBr39Uw1TvYougANOcU21Q0TP4J08VPGnOnpXk/FGbQ==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.1",
-        "@firebase/database-types": "0.7.2",
+        "@firebase/component": "0.5.5",
+        "@firebase/database-types": "0.7.3",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.1.0",
+        "@firebase/util": "1.2.0",
         "faye-websocket": "0.11.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@firebase/database-types": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
-      "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.3.tgz",
+      "integrity": "sha512-dSOJmhKQ0nL8O4EQMRNGpSExWCXeHtH57gGg0BfNAdWcKhC8/4Y+qfKLfWXzyHvrSecpLmO0SmAi/iK2D5fp5A==",
       "requires": {
-        "@firebase/app-types": "0.6.2"
+        "@firebase/app-types": "0.6.3"
       }
     },
     "@firebase/logger": {
@@ -90,24 +90,24 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/util": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-      "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-8W9TTGImXr9cu+oyjBJ7yjoEd/IVAv0pBZA4c1uIuKrpGZi2ee38m+8xlZOBRmsAaOU/tR9DXz1WF/oeM6Fb7Q==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "@google-cloud/common": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
-      "integrity": "sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.7.1.tgz",
+      "integrity": "sha512-BJfcV5BShbunYcn5HniebXLVp2Y6fpuesNegyar5CG8H2AKYHlKxnVID+FSwy92WAW4N2lpGdvxRsmiAn8Fc3w==",
       "optional": true,
       "requires": {
         "@google-cloud/projectify": "^2.0.0",
@@ -117,19 +117,19 @@
         "ent": "^2.2.0",
         "extend": "^3.0.2",
         "google-auth-library": "^7.0.2",
-        "retry-request": "^4.1.1",
+        "retry-request": "^4.2.2",
         "teeny-request": "^7.0.0"
       }
     },
     "@google-cloud/firestore": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.12.2.tgz",
-      "integrity": "sha512-5rurTAJXQ0SANEf8K9eA2JAB5zAh+pu4tGRnkZx5gBWQLZXdBFdtepS+irvKuSXw1KbeAQOuRANSc/nguys6SQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-ecPxrwsk3IWfyILHhVtRJXFcn+CFnlYRbnM6vwS+eEwHAfSFoy4tNXlsvh7c4YihuojAkvgl4+iBxPMwy5X09A==",
       "optional": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^2.12.0",
+        "google-gax": "^2.17.1",
         "protobufjs": "^6.8.6"
       }
     },
@@ -144,9 +144,9 @@
       }
     },
     "@google-cloud/projectify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
-      "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.0.tgz",
+      "integrity": "sha512-qbpidP/fOvQNz3nyabaVnZqcED1NNzf7qfeOlgtAZd9knTwY+KtsGRkYpiQzcATABy4gnGP2lousM3S0nuWVzA==",
       "optional": true
     },
     "@google-cloud/promisify": {
@@ -156,12 +156,12 @@
       "optional": true
     },
     "@google-cloud/storage": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.5.tgz",
-      "integrity": "sha512-i0gB9CRwQeOBYP7xuvn14M40LhHCwMjceBjxE4CTvsqL519sVY5yVKxLiAedHWGwUZHJNRa7Q2CmNfkdRwVNPg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.13.0.tgz",
+      "integrity": "sha512-LN3Cv7NRBbjwdwcrIFbEaKEEUCUr7aIoBa7j1HXeuBLjC1lQ5VGVGEbaLRP6uwgBKVnf5rFYSTA545C1GR+e/A==",
       "optional": true,
       "requires": {
-        "@google-cloud/common": "^3.6.0",
+        "@google-cloud/common": "^3.7.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
@@ -170,8 +170,7 @@
         "date-and-time": "^1.0.0",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "gcs-resumable-upload": "^3.1.4",
+        "gcs-resumable-upload": "^3.3.0",
         "get-stream": "^6.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
@@ -185,18 +184,18 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.2.tgz",
-      "integrity": "sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.7.tgz",
+      "integrity": "sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==",
       "optional": true,
       "requires": {
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.2.tgz",
-      "integrity": "sha512-q2Qle60Ht2OQBCp9S5hv1JbI4uBBq6/mqSevFNK3ZEgRDBCAkWqZPUhD/K9gXOHrHKluliHiVq2L9sw1mVyAIg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.4.tgz",
+      "integrity": "sha512-7xvDvW/vJEcmLUltCUGOgWRPM8Oofv0eCFSVMuKqaqWJaXSzmB+m9hiyqe34QofAl4WAzIKUZZlinIF9FOHyTQ==",
       "optional": true,
       "requires": {
         "@types/long": "^4.0.1",
@@ -298,10 +297,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+    },
     "@types/express": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.12.tgz",
-      "integrity": "sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -329,9 +333,9 @@
       }
     },
     "@types/express-unless": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
-      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
+      "integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
       "requires": {
         "@types/express": "*"
       }
@@ -810,9 +814,9 @@
       }
     },
     "duplexify": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "optional": true,
       "requires": {
         "end-of-stream": "^1.4.1",
@@ -1187,9 +1191,9 @@
       }
     },
     "firebase-admin": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.9.0.tgz",
-      "integrity": "sha512-04HT7JAAqcJYty95qf15IBD9CXf+vr7S8zNU6Zt1ayC1J05DLaCsUd19/sCNAjZ614KHexAYUtyLgZoJwu2wOQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.11.0.tgz",
+      "integrity": "sha512-68fXdwcKF99LkWBE33M5hnLwjvGpbCRznIOtZVsiBqZdM9iwxlTfNEpAckh++o3GdJcSLRUWmIN+MKqPUsxoCA==",
       "requires": {
         "@firebase/database": "^0.10.0",
         "@firebase/database-types": "^0.7.2",
@@ -1203,10 +1207,11 @@
       }
     },
     "firebase-functions": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.14.1.tgz",
-      "integrity": "sha512-hL/qm+i5i1qKYmAFMlQ4mwRngDkP+3YT3F4E4Nd5Hj2QKeawBdZiMGgEt6zqTx08Zq04vHiSnSM0z75UJRSg6Q==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.15.3.tgz",
+      "integrity": "sha512-1FupNg/bSrCH5All5BQ3ld7STKHWl3RAqlM2Dwf96Mf2RtOEeGt18Slh23A78igZTj7b++1Lg6fE2aGgzJT8LQ==",
       "requires": {
+        "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -1287,9 +1292,9 @@
       }
     },
     "gcp-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
+      "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
       "optional": true,
       "requires": {
         "gaxios": "^4.0.0",
@@ -1297,9 +1302,9 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.4.tgz",
-      "integrity": "sha512-5dyDfHrrVcIskiw/cPssVD4HRiwoHjhk1Nd6h5W3pQ/qffDvhfy4oNCr1f3ZXFPwTnxkCbibsB+73oOM+NvmJQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.3.0.tgz",
+      "integrity": "sha512-MQKWi+9hOSTyg5/SI1NBW4gAjL1wlkoevHefvr1PCBBXH4uKYLsug5qRrcotWKolDPLfWS51cWaHRN0CTtQNZw==",
       "optional": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -1344,9 +1349,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.1.1.tgz",
-      "integrity": "sha512-+Q1linq/To3DYLyPz4UTEkQ0v5EOXadMM/S+taLV3W9611hq9zqg8kgGApqbTQnggtwdO9yU1y2YT7+83wdTRg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.6.1.tgz",
+      "integrity": "sha512-aP/WTx+rE3wQ3zPgiCZsJ1EIb2v7P+QwxVwAqrKjcPz4SK57kyAfcX75VoAgjtwZzl70upcNlvFn8FSmC4nMBQ==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -1361,9 +1366,9 @@
       }
     },
     "google-gax": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.14.1.tgz",
-      "integrity": "sha512-I5RDEN7MEptrCxeHX3ht7nKFGfyjgYX4hQKI9eVMBohMzVbFSwWUndo0CcKXu8es7NhB4gt2XYLm1AHkXhtHpA==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.24.0.tgz",
+      "integrity": "sha512-PtE/Zk3jPrUIAL9YsIq5e+04U3aqEg6/0DmtR/tXKhbcS7SRA1sbPZja+vevuUavIdCXEiBbaKkrBqcQvSxXmw==",
       "optional": true,
       "requires": {
         "@grpc/grpc-js": "~1.3.0",
@@ -1372,33 +1377,34 @@
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.0.2",
+        "google-auth-library": "^7.3.0",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
         "object-hash": "^2.1.1",
-        "protobufjs": "^6.10.2",
+        "proto3-json-serializer": "^0.1.1",
+        "protobufjs": "6.11.2",
         "retry-request": "^4.0.0"
       }
     },
     "google-p12-pem": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
+      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
       "optional": true,
       "requires": {
         "node-forge": "^0.10.0"
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "optional": true
     },
     "gtoken": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
-      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
+      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
       "optional": true,
       "requires": {
         "gaxios": "^4.0.0",
@@ -1563,9 +1569,9 @@
       "optional": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "optional": true
     },
     "is-stream-ended": {
@@ -1686,15 +1692,25 @@
       }
     },
     "jwks-rsa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.0.3.tgz",
-      "integrity": "sha512-/rkjXRWAp0cS00tunsHResw68P5iTQru8+jHufLNv3JHc4nObFEndfEUSuPugh09N+V9XYxKUqi7QrkmCHSSSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.0.4.tgz",
+      "integrity": "sha512-iJqVCECYZZ+3oPmY1qXv3Fq+3ywDtuNEVBvG41pPlaR0zyGxa12nC0beAOBBUhETJmc05puS50mRQN4NkCGhmg==",
       "requires": {
         "@types/express-jwt": "0.0.42",
-        "debug": "^4.1.0",
+        "debug": "^4.3.2",
         "jose": "^2.0.5",
         "limiter": "^1.1.5",
-        "lru-memoizer": "^2.1.2"
+        "lru-memoizer": "^2.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "jws": {
@@ -2039,6 +2055,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "proto3-json-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.1.tgz",
+      "integrity": "sha512-Wucuvf7SqAw1wcai0zV+3jW3QZJiO/W9wZoJaTheebYdwfj2k9VfF3Gw9r2vGAaTeslhMbkVbojJG0+LjpgLxQ==",
+      "optional": true
+    },
     "protobufjs": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
@@ -2185,12 +2207,13 @@
       "optional": true
     },
     "retry-request": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-      "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
       "optional": true,
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
       }
     },
     "rimraf": {
@@ -2454,9 +2477,9 @@
       }
     },
     "teeny-request": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.0.tgz",
-      "integrity": "sha512-hPfSc05a7Mf3syqVhSkrVMb844sMiP60MrfGMts3ft6V6UlSkEIGQzgwf0dy1KjdE3FV2lJ5s7QCBFcaoQLA6g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
+      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
       "optional": true,
       "requires": {
         "http-proxy-agent": "^4.0.0",
@@ -2775,9 +2798,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.7",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "optional": true
     },
     "yocto-queue": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,8 +14,8 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "firebase-admin": "^9.9.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^9.11.0",
+    "firebase-functions": "^3.15.3"
   },
   "devDependencies": {
     "eslint": "^5.12.0",

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,31 @@
+// NOTE: Editing rules from the console can lead to conflicts. Always remember to update the GitHub
+// file as well, otherwise you risk your changes being overwritten.
+// https://firebase.google.com/docs/cli#deployment_conflicts
+
+rules_version = '2';
+service firebase.storage {
+    function isAuthenticated() {
+        return request.auth != null;
+    }
+
+    function isRightSize() {
+        return request.resource.size < 10 * 1024 * 1024;
+    }
+
+    match /b/{bucket}/o {
+        match /websites/{allPaths=**} {
+            allow read: if true;
+            allow write: if isAuthenticated() && isRightSize();
+        }
+
+        match /users/{user}/{allPaths=**} {
+            function isOwner() {
+                return isAuthenticated() && request.auth.uid == user;
+            }
+
+            allow read: if isOwner();
+            allow delete: if isOwner();
+            allow write: if isOwner() && isRightSize();
+        }
+    }
+}


### PR DESCRIPTION
This setup allows us to deploy security rules directly from the repo using the Firebase CLI. It is particularly useful for better versioning and for easily reviewing changes in security rules.

This closes #234.