### PR TITLE
 Don't require pubspec/changelog changes if the base branch isn't master.

### DIFF
--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -62,6 +62,7 @@ show_trivial_hint = false
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 has_test_changes = !git.modified_files.grep(/test/).empty?
 has_pubspec_changes = !git.modified_files.grep(/pubspec.yaml/).empty?
+base_branch_is_master = git.branch_for_base == "master"
 
 # Check that the tests were updated if there are app updates
 if !declared_trivial && has_app_changes && !has_test_changes
@@ -70,30 +71,30 @@ if !declared_trivial && has_app_changes && !has_test_changes
 end
 
 # Check that the pubspec version was updated
-if has_app_changes && !has_pubspec_changes
-    failure "No pubspec.yaml changes detected. Did you forget to update the version?"
-    show_versioning_info = true
-end
-
-if has_app_changes && has_pubspec_changes
-    diff = git.diff_for_file('pubspec.yaml')
-    if diff.patch !~ /\+version:/
-        failure "The pubspec.yaml file was updated, but not the version."
+if base_branch_is_master && has_app_changes
+    if !has_pubspec_changes
+        failure "No pubspec.yaml changes detected. Did you forget to update the version?"
         show_versioning_info = true
     else
-        old_version = diff.patch[/\-version: .*\+\K([0-9]+)/].to_i
-        new_version = diff.patch[/\+version: .*\+\K([0-9]+)/].to_i
-
-        if new_version - old_version != 1
-            failure "The build number in pubspec.yaml should be incremented by 1"
+        diff = git.diff_for_file('pubspec.yaml')
+        if diff.patch !~ /\+version:/
+            failure "The pubspec.yaml file was updated, but not the version."
             show_versioning_info = true
-        elsif !declared_trivial
-            ['en-GB', 'en-US', 'ro'].each do |language|
-                changelog_rxp = /android\/fastlane\/metadata\/android\/#{language}\/changelogs\/#{new_version + 10000}\.txt/
-                if git.added_files.grep(changelog_rxp).empty?
-                    changelog = "android/fastlane/metadata/android/#{language}/changelogs/#{new_version + 10000}.txt"
-                    warn "Missing #{language} changelog entry at #{changelog}"
-                    show_trivial_hint = true
+        else
+            old_version = diff.patch[/\-version: .*\+\K([0-9]+)/].to_i
+            new_version = diff.patch[/\+version: .*\+\K([0-9]+)/].to_i
+
+            if new_version - old_version != 1
+                failure "The build number in pubspec.yaml should be incremented by 1"
+                show_versioning_info = true
+            elsif !declared_trivial
+                ['en-GB', 'en-US', 'ro'].each do |language|
+                    changelog_rxp = /android\/fastlane\/metadata\/android\/#{language}\/changelogs\/#{new_version + 10000}\.txt/
+                    if git.added_files.grep(changelog_rxp).empty?
+                        changelog = "android/fastlane/metadata/android/#{language}/changelogs/#{new_version + 10000}.txt"
+                        warn "Missing #{language} changelog entry at #{changelog}"
+                        show_trivial_hint = true
+                    end
                 end
             end
         end

--- a/.github/linter/Dangerfile
+++ b/.github/linter/Dangerfile
@@ -62,7 +62,7 @@ show_trivial_hint = false
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 has_test_changes = !git.modified_files.grep(/test/).empty?
 has_pubspec_changes = !git.modified_files.grep(/pubspec.yaml/).empty?
-base_branch_is_master = git.branch_for_base == "master"
+base_branch_is_master = github.branch_for_base == "master"
 
 # Check that the tests were updated if there are app updates
 if !declared_trivial && has_app_changes && !has_test_changes

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,6 +98,7 @@ Future<void> main() async {
       },
     ),
   ], child: const MyApp()));
+  // TEST
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,7 +98,6 @@ Future<void> main() async {
       },
     ),
   ], child: const MyApp()));
-  // TEST
 }
 
 class MyApp extends StatefulWidget {


### PR DESCRIPTION
When merging a PR into a feature branch like web/layout/main, there is no need to update the changelog or increment the build number every time. This makes sure those checks are only done when trying to merge a PR into master.