### PR TITLE
Change text for password change error

### DIFF
--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -58,7 +58,7 @@ class AuthProvider with ChangeNotifier {
 
   void _errorHandler(dynamic e, {bool showToast = true}) {
     try {
-      print('$e.message e.code');
+      print('${e.message} code: ${e.code}');
       if (showToast) {
         switch (e.code) {
           case 'ERROR_INVALID_EMAIL':

--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -58,7 +58,7 @@ class AuthProvider with ChangeNotifier {
 
   void _errorHandler(dynamic e, {bool showToast = true}) {
     try {
-      print(e.message);
+      print('$e.message e.code');
       if (showToast) {
         switch (e.code) {
           case 'ERROR_INVALID_EMAIL':
@@ -80,6 +80,9 @@ class AuthProvider with ChangeNotifier {
             break;
           case 'ERROR_EMAIL_ALREADY_IN_USE':
             AppToast.show(S.current.errorEmailInUse);
+            break;
+          case 'wrong-password':
+            AppToast.show(S.current.errorIncorrectPassword);
             break;
           default:
             AppToast.show(e.message);

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -14,23 +14,22 @@ import 'intl/messages_all.dart';
 
 class S {
   S();
-
+  
   static S current;
-
-  static const AppLocalizationDelegate delegate = AppLocalizationDelegate();
+  
+  static const AppLocalizationDelegate delegate =
+    AppLocalizationDelegate();
 
   static Future<S> load(Locale locale) {
-    final name = (locale.countryCode?.isEmpty ?? false)
-        ? locale.languageCode
-        : locale.toString();
-    final localeName = Intl.canonicalizedLocale(name);
+    final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
+    final localeName = Intl.canonicalizedLocale(name); 
     return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       S.current = S();
-
+      
       return S.current;
     });
-  }
+  } 
 
   static S of(BuildContext context) {
     return Localizations.of<S>(context, S);
@@ -2879,10 +2878,8 @@ class AppLocalizationDelegate extends LocalizationsDelegate<S> {
 
   @override
   bool isSupported(Locale locale) => _isSupported(locale);
-
   @override
   Future<S> load(Locale locale) => S.load(locale);
-
   @override
   bool shouldReload(AppLocalizationDelegate old) => false;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,27 +78,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.3"
-  build:
-    dependency: transitive
-    description:
-      name: build
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.6.2"
-  built_collection:
-    dependency: transitive
-    description:
-      name: built_collection
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.1.0"
-  built_value:
-    dependency: transitive
-    description:
-      name: built_value
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.0.0-nullsafety.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -155,13 +134,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1+2"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.7.0"
   collection:
     dependency: transitive
     description:
@@ -379,13 +351,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+1"
-  fixnum:
-    dependency: transitive
-    description:
-      name: fixnum
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -615,7 +580,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.4"
+    version: "4.1.1+1"
   nested:
     dependency: transitive
     description:
@@ -629,7 +594,7 @@ packages:
       name: network_image_mock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.2"
   node_interop:
     dependency: transitive
     description:
@@ -901,13 +866,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.9.10+2"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,6 +78,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.3"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.0-nullsafety.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -134,6 +155,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1+2"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:
@@ -351,6 +379,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -580,7 +615,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1+1"
+    version: "4.1.4"
   nested:
     dependency: transitive
     description:
@@ -594,7 +629,7 @@ packages:
       name: network_image_mock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   node_interop:
     dependency: transitive
     description:
@@ -866,6 +901,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.10+2"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.13+24
+version: 1.2.13+25
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Removed the possibility that "the user doesn't have a password" from the error text. This happens at password change if the old password introduced is wrong.