### PR TITLE
Change message from toast to widget

### DIFF
--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -82,7 +82,6 @@ class AuthProvider with ChangeNotifier {
             AppToast.show(S.current.errorEmailInUse);
             break;
           case 'wrong-password':
-            AppToast.show(S.current.errorIncorrectPassword);
             break;
           default:
             AppToast.show(e.message);

--- a/lib/authentication/view/edit_profile_page.dart
+++ b/lib/authentication/view/edit_profile_page.dart
@@ -41,6 +41,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
   // Whether the user verified their email; this can be true, false or null if
   // the async check hasn't completed yet.
   bool isVerified;
+  bool correctPassword;
 
   @override
   void initState() {
@@ -75,6 +76,9 @@ class _EditProfilePageState extends State<EditProfilePage> {
                 validator: (value) {
                   if (value?.isEmpty ?? true) {
                     return S.current.errorNoPassword;
+                  }
+                  if (correctPassword == false) {
+                    return S.current.errorIncorrectPassword;
                   }
                   return null;
                 },
@@ -129,9 +133,12 @@ class _EditProfilePageState extends State<EditProfilePage> {
           color: Theme.of(context).accentColor,
           width: 130,
           onTap: () async {
+            correctPassword = false;
+            if (await authProvider.verifyPassword(oldPasswordController.text)) {
+              correctPassword = true;
+            }
             if (changePasswordKey.currentState.validate()) {
-              if (await authProvider
-                  .verifyPassword(oldPasswordController.text)) {
+              if (correctPassword == true) {
                 if (await authProvider
                     .changePassword(newPasswordController.text)) {
                   AppToast.show(S.current.messageChangePasswordSuccess);

--- a/lib/authentication/view/edit_profile_page.dart
+++ b/lib/authentication/view/edit_profile_page.dart
@@ -77,7 +77,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
                   if (value?.isEmpty ?? true) {
                     return S.current.errorNoPassword;
                   }
-                  if (correctPassword == false) {
+                  if (!correctPassword) {
                     return S.current.errorIncorrectPassword;
                   }
                   return null;
@@ -133,12 +133,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
           color: Theme.of(context).accentColor,
           width: 130,
           onTap: () async {
-            correctPassword = false;
-            if (await authProvider.verifyPassword(oldPasswordController.text)) {
-              correctPassword = true;
-            }
+            correctPassword =
+                await authProvider.verifyPassword(oldPasswordController.text);
             if (changePasswordKey.currentState.validate()) {
-              if (correctPassword == true) {
+              if (correctPassword) {
                 if (await authProvider
                     .changePassword(newPasswordController.text)) {
                   AppToast.show(S.current.messageChangePasswordSuccess);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.13+25
+version: 1.2.13+26
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
On changing your password, every error message is a text widget under its corresponding field, except for the 'wrong password' one, which is a toast.