### PR TITLE
Fix crash on settings page when anonymous

### DIFF
--- a/lib/pages/settings/view/settings_page.dart
+++ b/lib/pages/settings/view/settings_page.dart
@@ -116,7 +116,9 @@ class _SettingsPageState extends State<SettingsPage> {
                   ),
                 ),
                 Visibility(
-                  visible: authProvider.currentUserFromCache.isAdmin == true,
+                  visible: authProvider.isAuthenticated &&
+                      !authProvider.isAnonymous &&
+                      authProvider.currentUserFromCache.isAdmin == true,
                   child: ListTile(
                     key: const Key('AdminPanel'),
                     onTap: () =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.3.0+34
+version: 1.3.0+35
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
The app is checking for the permission level of the user without checking if the user is authenticated and not anonymous first.