### PR TITLE
Hide home cards with not items, but keep old "not-yet" functionality

### DIFF
--- a/lib/pages/home/favourite_websites_card.dart
+++ b/lib/pages/home/favourite_websites_card.dart
@@ -15,8 +15,6 @@ class FavouriteWebsitesCard extends StatelessWidget {
 
   final void Function() onShowMore;
 
-  Widget showWhenNoItems() => const SizedBox.shrink();
-
   @override
   Widget build(final BuildContext context) {
     final AuthProvider authProvider = Provider.of<AuthProvider>(context);
@@ -27,7 +25,7 @@ class FavouriteWebsitesCard extends StatelessWidget {
       title: S.current.sectionFrequentlyAccessedWebsites,
       onShowMore: onShowMore,
       future: websiteProvider.fetchFavouriteWebsites(uid),
-      showWhenNoItems: showWhenNoItems(),
+      showIfEmpty: false,
       builder: (final websites) => Padding(
         padding: const EdgeInsets.only(top: 10),
         child: Row(

--- a/lib/pages/home/favourite_websites_card.dart
+++ b/lib/pages/home/favourite_websites_card.dart
@@ -15,6 +15,8 @@ class FavouriteWebsitesCard extends StatelessWidget {
 
   final void Function() onShowMore;
 
+  Widget showWhenNoItems() => const SizedBox.shrink();
+
   @override
   Widget build(final BuildContext context) {
     final AuthProvider authProvider = Provider.of<AuthProvider>(context);
@@ -25,6 +27,7 @@ class FavouriteWebsitesCard extends StatelessWidget {
       title: S.current.sectionFrequentlyAccessedWebsites,
       onShowMore: onShowMore,
       future: websiteProvider.fetchFavouriteWebsites(uid),
+      showWhenNoItems: showWhenNoItems(),
       builder: (final websites) => Padding(
         padding: const EdgeInsets.only(top: 10),
         child: Row(

--- a/lib/pages/home/upcoming_events_card.dart
+++ b/lib/pages/home/upcoming_events_card.dart
@@ -11,8 +11,6 @@ class UpcomingEventsCard extends StatelessWidget {
   const UpcomingEventsCard({final Key key, this.onShowMore}) : super(key: key);
   final void Function() onShowMore;
 
-  Widget showWhenNoItems() => const SizedBox.shrink();
-
   @override
   Widget build(final BuildContext context) {
     final UniEventProvider eventProvider =
@@ -21,7 +19,7 @@ class UpcomingEventsCard extends StatelessWidget {
     return InfoCard<Iterable<UniEventInstance>>(
       title: S.current.sectionEventsComingUp,
       onShowMore: onShowMore,
-      showWhenNoItems: showWhenNoItems(),
+      showIfEmpty: false,
       future: eventProvider.getUpcomingEvents(DateTime.now()),
       builder: (final events) => Column(
         children: events

--- a/lib/pages/home/upcoming_events_card.dart
+++ b/lib/pages/home/upcoming_events_card.dart
@@ -11,6 +11,8 @@ class UpcomingEventsCard extends StatelessWidget {
   const UpcomingEventsCard({final Key key, this.onShowMore}) : super(key: key);
   final void Function() onShowMore;
 
+  Widget showWhenNoItems() => const SizedBox.shrink();
+
   @override
   Widget build(final BuildContext context) {
     final UniEventProvider eventProvider =
@@ -19,6 +21,7 @@ class UpcomingEventsCard extends StatelessWidget {
     return InfoCard<Iterable<UniEventInstance>>(
       title: S.current.sectionEventsComingUp,
       onShowMore: onShowMore,
+      showWhenNoItems: showWhenNoItems(),
       future: eventProvider.getUpcomingEvents(DateTime.now()),
       builder: (final events) => Column(
         children: events

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -8,7 +8,7 @@ class InfoCard<T> extends StatelessWidget {
       {@required this.future,
         @required this.builder,
         this.onShowMore,
-        this.showWhenNoItems,
+        this.showIfEmpty = false,
         this.title,
         this.showMoreButtonKey,
         this.padding});
@@ -19,7 +19,7 @@ class InfoCard<T> extends StatelessWidget {
   final String title;
   final ValueKey<String> showMoreButtonKey;
   final EdgeInsetsGeometry padding;
-  final Widget showWhenNoItems;
+  final bool showIfEmpty;
 
   @override
   Widget build(final BuildContext context) {
@@ -32,26 +32,11 @@ class InfoCard<T> extends StatelessWidget {
               if ((snapshot.data is Map ||
                   snapshot.data is Iterable) &&
                   snapshot.data.isEmpty) {
-                return showWhenNoItems
-                    ?? cardWrapper(
-                        context,
-                        cardBar(context, title, showMoreButtonKey, onShowMore),
-                        noneYet(context),
-                        padding);
+                return showIfEmpty ? cardWrapper(context, noneYet(context)) : const SizedBox();
               }
-
-              return cardWrapper(
-                  context,
-                  cardBar(context, title, showMoreButtonKey, onShowMore),
-                  builder(snapshot.data),
-                  padding);
+              return cardWrapper(context, builder(snapshot.data));
             } else {
-              return showWhenNoItems
-                  ?? cardWrapper(
-                      context,
-                      cardBar(context, title, showMoreButtonKey, onShowMore),
-                      noneYet(context),
-                      padding);
+              return showIfEmpty ? cardWrapper(context, noneYet(context)) : const SizedBox();
             }
           }
           return const SizedBox(
@@ -63,9 +48,7 @@ class InfoCard<T> extends StatelessWidget {
 
   Widget cardWrapper(
       final BuildContext context,
-      final Widget cardBar,
-      final Widget content,
-      final EdgeInsetsGeometry padding
+      final Widget cardContent
       ) => Padding(
       padding: padding ?? const EdgeInsets.fromLTRB(12, 12, 12, 0),
       child: Card(
@@ -73,9 +56,9 @@ class InfoCard<T> extends StatelessWidget {
               padding: const EdgeInsets.all(12),
               child: Column(
                   children: <Widget>[
-                    cardBar,
+                    cardHeader(context),
                     const SizedBox(height: 10),
-                    content,
+                    cardContent,
                   ]
               )
           )
@@ -93,11 +76,8 @@ class InfoCard<T> extends StatelessWidget {
     ),
   );
 
-  Widget cardBar(
-      final BuildContext context,
-      final String title,
-      final ValueKey<String> showMoreButtonKey,
-      final Function onShowMore
+  Widget cardHeader(
+      final BuildContext context
       ) => Row(
     mainAxisAlignment: MainAxisAlignment.spaceBetween,
     children: [

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -6,11 +6,12 @@ import '../resources/theme.dart';
 class InfoCard<T> extends StatelessWidget {
   const InfoCard(
       {@required this.future,
-      @required this.builder,
-      this.onShowMore,
-      this.title,
-      this.showMoreButtonKey,
-      this.padding});
+        @required this.builder,
+        this.onShowMore,
+        this.showWhenNoItems,
+        this.title,
+        this.showMoreButtonKey,
+        this.padding});
 
   final Function onShowMore;
   final Future<T> future;
@@ -18,92 +19,123 @@ class InfoCard<T> extends StatelessWidget {
   final String title;
   final ValueKey<String> showMoreButtonKey;
   final EdgeInsetsGeometry padding;
+  final Widget showWhenNoItems;
 
   @override
   Widget build(final BuildContext context) {
-    return Padding(
+
+    return FutureBuilder(
+        future: future,
+        builder: (final context, final snapshot) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            if (snapshot.hasData) {
+              if ((snapshot.data is Map ||
+                  snapshot.data is Iterable) &&
+                  snapshot.data.isEmpty) {
+                return showWhenNoItems
+                    ?? cardWrapper(
+                        context,
+                        cardBar(context, title, showMoreButtonKey, onShowMore),
+                        noneYet(context),
+                        padding);
+              }
+
+              return cardWrapper(
+                  context,
+                  cardBar(context, title, showMoreButtonKey, onShowMore),
+                  builder(snapshot.data),
+                  padding);
+            } else {
+              return showWhenNoItems
+                  ?? cardWrapper(
+                      context,
+                      cardBar(context, title, showMoreButtonKey, onShowMore),
+                      noneYet(context),
+                      padding);
+            }
+          }
+          return const SizedBox(
+            height: 100,
+            child: Center(child: CircularProgressIndicator()),
+          );
+        });
+  }
+
+  Widget cardWrapper(
+      final BuildContext context,
+      final Widget cardBar,
+      final Widget content,
+      final EdgeInsetsGeometry padding
+      ) => Padding(
       padding: padding ?? const EdgeInsets.fromLTRB(12, 12, 12, 0),
       child: Card(
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            children: <Widget>[
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  if (title != null && title.isNotEmpty)
-                    Expanded(
-                      child: Text(
-                        title,
-                        style: Theme.of(context)
-                            .textTheme
-                            .headline6
-                            .copyWith(fontSize: 18),
-                        overflow: TextOverflow.fade,
-                        maxLines: 2,
-                      ),
-                    ),
-                  if (onShowMore != null)
-                    GestureDetector(
-                      onTap: onShowMore,
-                      key: showMoreButtonKey ?? const ValueKey('show_more'),
-                      child: Row(
-                        children: <Widget>[
-                          Text(
-                            S.current.actionShowMore,
-                            style: Theme.of(context)
-                                .coloredTextTheme
-                                .subtitle2
-                                .copyWith(
-                                    color: Theme.of(context).primaryColor),
-                          ),
-                          Icon(
-                            Icons.arrow_forward_ios_outlined,
-                            color: Theme.of(context).primaryColor,
-                            size:
-                                Theme.of(context).textTheme.subtitle2.fontSize,
-                          )
-                        ],
-                      ),
-                    ),
-                ],
-              ),
-              const SizedBox(height: 10),
-              FutureBuilder(
-                  future: future,
-                  builder: (final context, final snapshot) {
-                    if (snapshot.connectionState == ConnectionState.done) {
-                      if (snapshot.hasData) {
-                        if ((snapshot.data is Map ||
-                                snapshot.data is Iterable) &&
-                            snapshot.data.isEmpty) {
-                          return noneYet(context);
-                        }
+          child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                  children: <Widget>[
+                    cardBar,
+                    const SizedBox(height: 10),
+                    content,
+                  ]
+              )
+          )
+      )
+  );
 
-                        return builder(snapshot.data);
-                      } else {
-                        return noneYet(context);
-                      }
-                    }
-                    return const SizedBox(
-                      height: 100,
-                      child: Center(child: CircularProgressIndicator()),
-                    );
-                  }),
+  Widget noneYet(
+      final BuildContext context) => SizedBox(
+    height: 100,
+    child: Center(
+      child: Text(
+        S.current.warningNoneYet,
+        style: TextStyle(color: Theme.of(context).disabledColor),
+      ),
+    ),
+  );
+
+  Widget cardBar(
+      final BuildContext context,
+      final String title,
+      final ValueKey<String> showMoreButtonKey,
+      final Function onShowMore
+      ) => Row(
+    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    children: [
+      if (title != null && title.isNotEmpty)
+        Expanded(
+          child: Text(
+            title,
+            style: Theme.of(context)
+                .textTheme
+                .headline6
+                .copyWith(fontSize: 18),
+            overflow: TextOverflow.fade,
+            maxLines: 2,
+          ),
+        ),
+      if (onShowMore != null)
+        GestureDetector(
+          onTap: onShowMore,
+          key: showMoreButtonKey ?? const ValueKey('show_more'),
+          child: Row(
+            children: <Widget>[
+              Text(
+                S.current.actionShowMore,
+                style: Theme.of(context)
+                    .coloredTextTheme
+                    .subtitle2
+                    .copyWith(
+                    color: Theme.of(context).primaryColor),
+              ),
+              Icon(
+                Icons.arrow_forward_ios_outlined,
+                color: Theme.of(context).primaryColor,
+                size:
+                Theme.of(context).textTheme.subtitle2.fontSize,
+              )
             ],
           ),
         ),
-      ),
-    );
-  }
-
-  Widget noneYet(final BuildContext context) => SizedBox(
-        height: 100,
-        child: Center(
-          child: Text(
-            S.current.warningNoneYet,
-            style: TextStyle(color: Theme.of(context).disabledColor),
-          ),
-        ),
-      );
+    ],
+  );
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24855378/164111912-3e98de02-449e-4dc4-86f1-6f1b46deb573.png)
![image](https://user-images.githubusercontent.com/24855378/164111967-1b3cc4a0-fd7c-4e4a-ac4b-e8c7e27e3a25.png)

Each info card on the home page is able to receive a new parameter called `showWhenNoItems` which should be a corespondent widget for when there are no available card items. If a null value is provided, the info card widget will default to its old "not-yet" functionality.
